### PR TITLE
Fix missing issuer in HC1 payload.

### DIFF
--- a/eu.dgc.html
+++ b/eu.dgc.html
@@ -680,7 +680,7 @@ AF7zi+d862ePRQ9Lwymr7XfwVm0=
 
             function signAndDisplayEUQR(elemPref, json, priKeyPEM, pubKeyPem) {
                 const eu45t0 = performance.now();
-                DCC.makeCWT(json, parseInt(e("qr-cert-exp").value)).then(cwt => {
+                DCC.makeCWT(json, parseInt(e("qr-cert-exp").value), e("qr-cert-iss").value).then(cwt => {
                     DCC.signAndPack(cwt, pubKeyPem, priKeyPEM).then(uri => {
                         const eu45t1 = performance.now();
                         UIUtils.renderQR(elemPref, uri);


### PR DESCRIPTION
The certificate issuer is missing from the HC1 certificate which makes it fail to scan for some apps (e.g. Corona Warn App). This pull request adds the issuer.